### PR TITLE
Add missing <cstdint> include to bdd.hpp :)

### DIFF
--- a/include/bdd.hpp
+++ b/include/bdd.hpp
@@ -37,6 +37,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 class BDD
 {


### PR DESCRIPTION
This header file uses uint32_t and such, but doesn't actually include <cstdint> / <stdint.h>

Some compilers (e.g. clang) automatically know about those types, but this causes problems on GCC.