### PR TITLE
Replace compiler-specific fallthrough with more general form

### DIFF
--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -107,21 +107,21 @@ static uint64_t hash128(const void* key, const uint64_t len)
 
     switch(len & 15)
     {
-        case 15: k2 ^= ((uint64_t)tail[14]) << 48; [[clang::fallthrough]];
-        case 14: k2 ^= ((uint64_t)tail[13]) << 40; [[clang::fallthrough]];
-        case 13: k2 ^= ((uint64_t)tail[12]) << 32; [[clang::fallthrough]];
-        case 12: k2 ^= ((uint64_t)tail[11]) << 24; [[clang::fallthrough]];
-        case 11: k2 ^= ((uint64_t)tail[10]) << 16; [[clang::fallthrough]];
-        case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;  [[clang::fallthrough]];
+        case 15: k2 ^= ((uint64_t)tail[14]) << 48; [[fallthrough]];
+        case 14: k2 ^= ((uint64_t)tail[13]) << 40; [[fallthrough]];
+        case 13: k2 ^= ((uint64_t)tail[12]) << 32; [[fallthrough]];
+        case 12: k2 ^= ((uint64_t)tail[11]) << 24; [[fallthrough]];
+        case 11: k2 ^= ((uint64_t)tail[10]) << 16; [[fallthrough]];
+        case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;  [[fallthrough]];
         case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
-            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; [[clang::fallthrough]];
-        case  8: k1 ^= ((uint64_t)tail[ 7]) << 56; [[clang::fallthrough]];
-        case  7: k1 ^= ((uint64_t)tail[ 6]) << 48; [[clang::fallthrough]];
-        case  6: k1 ^= ((uint64_t)tail[ 5]) << 40; [[clang::fallthrough]];
-        case  5: k1 ^= ((uint64_t)tail[ 4]) << 32; [[clang::fallthrough]];
-        case  4: k1 ^= ((uint64_t)tail[ 3]) << 24; [[clang::fallthrough]];
-        case  3: k1 ^= ((uint64_t)tail[ 2]) << 16; [[clang::fallthrough]];
-        case  2: k1 ^= ((uint64_t)tail[ 1]) << 8; [[clang::fallthrough]];
+            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; [[fallthrough]];
+        case  8: k1 ^= ((uint64_t)tail[ 7]) << 56; [[fallthrough]];
+        case  7: k1 ^= ((uint64_t)tail[ 6]) << 48; [[fallthrough]];
+        case  6: k1 ^= ((uint64_t)tail[ 5]) << 40; [[fallthrough]];
+        case  5: k1 ^= ((uint64_t)tail[ 4]) << 32; [[fallthrough]];
+        case  4: k1 ^= ((uint64_t)tail[ 3]) << 24; [[fallthrough]];
+        case  3: k1 ^= ((uint64_t)tail[ 2]) << 16; [[fallthrough]];
+        case  2: k1 ^= ((uint64_t)tail[ 1]) << 8; [[fallthrough]];
         case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
             k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
         default: // do nothing;


### PR DESCRIPTION
The C++ attribute [[fallthrough]] was standardized in C++ 17 (see: [here](https://en.cppreference.com/w/cpp/language/attributes/fallthrough) )
Currently, all major compilers support it :)

On GCC, trying to compile hash.hpp creates a compiler error by default, as it doesn't know about the clang-specific clang::fallthrough attribute.

Replacing it with the more general standardized form fixes compilation on GCC without affecting Clang builds at all.